### PR TITLE
Je voudrais revoir un peu le system de craft.

### DIFF
--- a/app/data/cards.yml
+++ b/app/data/cards.yml
@@ -680,7 +680,8 @@ cards:
       resources: {}
     show_in_main_shop: false
     show_in_village_shop: true
-    buy_rules: null
+    buy_rules:
+      requires_card: access_craft_table_medium
   tradable: false
   giftable: true
   card_quantity: 0
@@ -740,7 +741,8 @@ cards:
       resources: {}
     show_in_main_shop: false
     show_in_village_shop: true
-    buy_rules: null
+    buy_rules:
+      requires_card: access_craft_table_basic
   tradable: false
   giftable: true
   card_quantity: 0

--- a/app/data/cards/craft/access.yml
+++ b/app/data/cards/craft/access.yml
@@ -51,7 +51,8 @@
       resources: {}
     show_in_main_shop: false
     show_in_village_shop: true
-    buy_rules: null
+    buy_rules:
+      requires_card: access_craft_table_basic
   tradable: false
   giftable: true
   card_quantity: 0
@@ -81,7 +82,8 @@
       resources: {}
     show_in_main_shop: false
     show_in_village_shop: true
-    buy_rules: null
+    buy_rules:
+      requires_card: access_craft_table_medium
   tradable: false
   giftable: true
   card_quantity: 0

--- a/app/models.py
+++ b/app/models.py
@@ -61,6 +61,9 @@ class Player(Base):
     
     lang: Mapped[str] = mapped_column(String(5), default="fr", nullable=False)
 
+    # Craft queue: number of extra slots purchased beyond the base 2 (1 active + 1 queued)
+    craft_queue_extra_slots: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
     account: Mapped["Account"] = relationship(
         "Account",
         back_populates="player",

--- a/app/routes/api_craft.py
+++ b/app/routes/api_craft.py
@@ -15,7 +15,12 @@ from app.db import SessionLocal
 from app.models import Player, PlayerCard, ResourceStock, PlayerItem, PlayerCraftJob
 from app.auth import get_current_player
 from app.quests.service import on_item_crafted
-from app.services.crafts import compute_craft_table_level, update_craft_jobs_for_player
+from app.services.crafts import (
+    compute_craft_table_level,
+    update_craft_jobs_for_player,
+    get_craft_queue_max_slots,
+    get_craft_next_slot_cost,
+)
 from app.progression import next_threshold, apply_xp_and_level_up
 
 from datetime import datetime, timedelta
@@ -552,6 +557,23 @@ def perform_craft():
                 }
             ), 403
 
+        # --- Check queue capacity (only for delayed crafts) ----------------
+        craft_time_seconds = int(recipe.get("craft_time_seconds") or 0)
+        if craft_time_seconds > 0:
+            max_slots = get_craft_queue_max_slots(player)
+            occupied = (
+                session.query(PlayerCraftJob)
+                .filter(PlayerCraftJob.player_id == player.id)
+                .filter(PlayerCraftJob.status.in_(["active", "queued"]))
+                .count()
+            )
+            if occupied >= max_slots:
+                return jsonify({
+                    "error": "craft_queue_full",
+                    "max_slots": max_slots,
+                    "occupied": occupied,
+                }), 400
+
         # --- Compute total cost (resources + items) -------------------------
         required_resources, required_items = _compute_required_cost(
             recipe,
@@ -648,7 +670,6 @@ def perform_craft():
 
         # --- Compute total output ------------------------------------------
         output_qty = int(recipe.get("output_quantity") or 1) * times
-        craft_time_seconds = int(recipe.get("craft_time_seconds") or 0)
         
         # --- XP reward -----------------------------------------------------
         xp_reward = float(item_cfg.get("xp_reward") or 0.0)
@@ -697,21 +718,42 @@ def perform_craft():
             delayed = False
             job_payload = None
 
-        # --- Delayed craft: create PlayerCraftJob --------------------------
+        # --- Delayed craft: create PlayerCraftJob (active or queued) -------
         else:
-            total_seconds = craft_time_seconds * output_qty
-            ends_at = now + timedelta(seconds=total_seconds)
+            # Determine if we should queue or activate immediately
+            has_active = (
+                session.query(PlayerCraftJob)
+                .filter(PlayerCraftJob.player_id == player.id)
+                .filter(PlayerCraftJob.status == "active")
+                .count()
+            ) > 0
 
-            job = PlayerCraftJob(
-                player_id=player.id,
-                item_key=item_cfg.get("key"),
-                craft_location=craft_location or recipe_location,
-                quantity_total=output_qty,
-                quantity_done=0,
-                started_at=now,
-                ends_at=ends_at,
-                status="active",
-            )
+            total_seconds = craft_time_seconds * output_qty
+
+            if has_active:
+                # Queue it: started_at/ends_at will be set when promoted
+                job = PlayerCraftJob(
+                    player_id=player.id,
+                    item_key=item_cfg.get("key"),
+                    craft_location=craft_location or recipe_location,
+                    quantity_total=output_qty,
+                    quantity_done=0,
+                    started_at=now,
+                    ends_at=now + timedelta(seconds=total_seconds),  # placeholder
+                    status="queued",
+                )
+            else:
+                ends_at = now + timedelta(seconds=total_seconds)
+                job = PlayerCraftJob(
+                    player_id=player.id,
+                    item_key=item_cfg.get("key"),
+                    craft_location=craft_location or recipe_location,
+                    quantity_total=output_qty,
+                    quantity_done=0,
+                    started_at=now,
+                    ends_at=ends_at,
+                    status="active",
+                )
             session.add(job)
 
             delayed = True
@@ -723,6 +765,7 @@ def perform_craft():
                 "started_at": job.started_at.isoformat(),
                 "ends_at": job.ends_at.isoformat(),
                 "seconds_total": total_seconds,
+                "status": job.status,
             }
 
         session.commit()
@@ -757,3 +800,50 @@ def perform_craft():
             resp["job"] = job_payload
 
         return jsonify(resp)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/craft/queue/buy_slot
+# ---------------------------------------------------------------------------
+@bp.post("/craft/queue/buy_slot")
+def buy_craft_queue_slot():
+    """
+    Purchase an additional craft queue slot using essence.
+
+    Cost doubles each time: 2, 4, 8, 16 ... essence.
+    """
+    data = request.get_json(silent=True) or {}
+
+    with SessionLocal() as session:
+        player = _resolve_player(session, data)
+        if not player:
+            return jsonify({"error": "player_required"}), 400
+
+        cost = get_craft_next_slot_cost(player)
+
+        if player.essence < cost:
+            return jsonify({
+                "error": "not_enough_essence",
+                "required": cost,
+                "owned": player.essence,
+            }), 400
+
+        player.essence -= cost
+        player.craft_queue_extra_slots = int(
+            getattr(player, "craft_queue_extra_slots", 0) or 0
+        ) + 1
+
+        session.commit()
+        session.refresh(player)
+
+        return jsonify({
+            "ok": True,
+            "extra_slots": player.craft_queue_extra_slots,
+            "max_queue_slots": get_craft_queue_max_slots(player),
+            "next_slot_cost": get_craft_next_slot_cost(player),
+            "player": {
+                "id": player.id,
+                "essence": player.essence,
+                "shards": player.shards,
+            },
+        })

--- a/app/routes/api_players.py
+++ b/app/routes/api_players.py
@@ -33,7 +33,12 @@ from app.quests.service import (
 
 from app.services.cards import serialize_card_def
 #from app.routes.api_craft import _compute_craft_table_level, _update_craft_jobs_for_player
-from app.services.crafts import compute_craft_table_level, update_craft_jobs_for_player
+from app.services.crafts import (
+    compute_craft_table_level,
+    update_craft_jobs_for_player,
+    get_craft_queue_max_slots,
+    get_craft_next_slot_cost,
+)
 from app.i18n import get_item, get_user_language  # ✅ AJOUTÉ
 from app.auth import get_current_player
 
@@ -450,24 +455,33 @@ def get_state():
         # Craft : niveau de table + jobs en cours
         # -------------------------------------------------------------------
 
-        # 1) Mettre à jour les jobs en cours (donne les items terminés)
-        #_update_craft_jobs_for_player(s, me)
+        # 1) Mettre à jour les jobs en cours (crédite les crafts finis, promeut la file)
+        just_completed_keys = update_craft_jobs_for_player(s, me)
+        s.flush()
 
         # 2) Niveau de table
         craft_table_level = compute_craft_table_level(s, me)
 
-        # 3) Charger les jobs actifs
+        # 3) Charger les jobs actifs ET en file d'attente
         now = dt.datetime.utcnow()
         job_rows = (
             s.query(PlayerCraftJob)
             .filter(PlayerCraftJob.player_id == me.id)
-            .filter(PlayerCraftJob.status == "active")
-            .order_by(PlayerCraftJob.started_at.asc())
+            .filter(PlayerCraftJob.status.in_(["active", "queued"]))
+            .order_by(PlayerCraftJob.id.asc())
             .all()
         )
 
-        jobs_payload = []
-        for job in job_rows:
+        # 4) Recently-completed jobs (dans les 60 dernières secondes)
+        recently_completed_rows = (
+            s.query(PlayerCraftJob)
+            .filter(PlayerCraftJob.player_id == me.id)
+            .filter(PlayerCraftJob.status == "done")
+            .filter(PlayerCraftJob.ends_at >= now - dt.timedelta(seconds=60))
+            .all()
+        )
+
+        def _serialize_job(job, now):
             total = int(job.quantity_total or 0)
             done = int(job.quantity_done or 0)
             remaining_units = max(0, total - done)
@@ -475,44 +489,29 @@ def get_state():
             started_at = job.started_at
             ends_at = job.ends_at
 
-            total_secs = max(
-                0, int((ends_at - started_at).total_seconds())
-            )
-            elapsed = max(0, int((now - started_at).total_seconds()))
-            remaining_total_secs = max(0, total_secs - elapsed)
-
-            # Durée par item (approx) si on a un total non nul
-            if total > 0 and total_secs > 0:
-                seconds_per_unit = total_secs / total
+            if job.status == "active":
+                total_secs = max(0, int((ends_at - started_at).total_seconds()))
+                elapsed = max(0, int((now - started_at).total_seconds()))
+                remaining_total_secs = max(0, total_secs - elapsed)
             else:
-                seconds_per_unit = 0
+                # queued: compute expected duration from defs
+                cfg_j = craft_defs.CRAFT_DEFS.get(job.item_key, {}) or {}
+                recipe_j = cfg_j.get("recipe") or {}
+                craft_time_per_unit = int(recipe_j.get("craft_time_seconds") or 0)
+                total_secs = craft_time_per_unit * total
+                elapsed = 0
+                remaining_total_secs = total_secs
 
-            # Temps jusqu'au prochain item (approx)
-            if remaining_units > 0 and seconds_per_unit > 0:
-                # Combien d'items *devraient* être finis à cet instant ?
-                units_should_be_done = min(
-                    total, int(elapsed // seconds_per_unit)
-                )
-                next_threshold_time = (
-                    units_should_be_done + 1
-                ) * seconds_per_unit
-                seconds_until_next_unit = max(
-                    0, int(next_threshold_time - elapsed)
-                )
-                if seconds_until_next_unit > remaining_total_secs:
-                    seconds_until_next_unit = remaining_total_secs
-            else:
-                seconds_until_next_unit = 0
+            cfg_j2 = craft_defs.CRAFT_DEFS.get(job.item_key, {}) or {}
+            label_j = cfg_j2.get("label") or job.item_key
+            icon_j = cfg_j2.get("icon") or None
 
-            # Label / meta depuis craft_defs si dispo
-            cfg = craft_defs.CRAFT_DEFS.get(job.item_key, {}) or {}
-            label = cfg.get("label") or job.item_key
-
-            job_payload = {
+            return {
                 "id": job.id,
                 "station_key": job.craft_location,
                 "item_key": job.item_key,
-                "label": label,
+                "label": label_j,
+                "icon": icon_j,
                 "quantity_total": total,
                 "quantity_done": done,
                 "remaining_units": remaining_units,
@@ -521,26 +520,42 @@ def get_state():
                 "seconds_total": total_secs,
                 "seconds_elapsed": elapsed,
                 "seconds_remaining_total": remaining_total_secs,
-                "seconds_per_unit": int(seconds_per_unit)
-                if seconds_per_unit
-                else 0,
-                "seconds_until_next_unit": seconds_until_next_unit,
                 "status": job.status,
             }
-            jobs_payload.append(job_payload)
 
-        # Pour l'instant, on considère qu'il n'y a qu'une seule table de craft "générique"
-        # -> on expose un "active_job" pratique pour l'UI sur craft_table
+        jobs_payload = [_serialize_job(j, now) for j in job_rows]
+
+        # active_job = first active job for craft_table
         active_job = None
+        queue_jobs = []
         for jp in jobs_payload:
             if jp["station_key"].startswith("craft_table"):
-                active_job = jp
-                break
+                if jp["status"] == "active" and active_job is None:
+                    active_job = jp
+                elif jp["status"] == "queued":
+                    queue_jobs.append(jp)
+
+        # recently completed info
+        recently_completed = []
+        for job in recently_completed_rows:
+            cfg_rc = craft_defs.CRAFT_DEFS.get(job.item_key, {}) or {}
+            recently_completed.append({
+                "id": job.id,
+                "item_key": job.item_key,
+                "label": cfg_rc.get("label") or job.item_key,
+                "icon": cfg_rc.get("icon") or None,
+                "quantity_total": job.quantity_total,
+            })
 
         craft_payload = {
             "craft_table_level": craft_table_level,
             "jobs": jobs_payload,
             "active_job": active_job,
+            "queue_jobs": queue_jobs,
+            "max_queue_slots": get_craft_queue_max_slots(me),
+            "extra_slots": int(getattr(me, "craft_queue_extra_slots", 0) or 0),
+            "next_slot_cost": get_craft_next_slot_cost(me),
+            "recently_completed": recently_completed,
         }
 
         # -------------------------------------------------------------------

--- a/app/routes/api_village_cardshop.py
+++ b/app/routes/api_village_cardshop.py
@@ -86,6 +86,22 @@ def api_village_cardshop_buy():
                 {"ok": False, "error": "max_owned_reached"}
             ), 400
 
+        # Check buy_rules: prerequisite card ownership
+        buy_rules = shop_cfg.get("buy_rules") or {}
+        requires_card = buy_rules.get("requires_card")
+        if requires_card:
+            has_prereq = (
+                session.query(PlayerCard)
+                .filter_by(player_id=player.id, card_key=requires_card)
+                .count()
+            ) > 0
+            if not has_prereq:
+                return jsonify({
+                    "ok": False,
+                    "error": "prerequisite_card_required",
+                    "requires_card": requires_card,
+                }), 400
+
         # (optionnel) Ressources requises -> à implémenter plus tard
         if res_costs:
             # TODO: vérifier les ressources du joueur

--- a/app/services/crafts.py
+++ b/app/services/crafts.py
@@ -215,13 +215,33 @@ def compute_craft_table_level(session: Session, player: Player) -> int:
     return level
 
 
-def update_craft_jobs_for_player(session: Session, player: Player) -> None:
+def get_craft_queue_max_slots(player: Player) -> int:
     """
-    Update all active craft jobs for this player:
-      - compute how many units should be completed based on time
-      - credit missing items into PlayerItem
-      - mark job as done when finished
+    Return the total number of craft queue slots available to a player.
+    Base is 2 (1 active + 1 queued). Each extra slot purchased adds 1 more.
+    """
+    extra = int(getattr(player, "craft_queue_extra_slots", 0) or 0)
+    return 2 + extra
 
+
+def get_craft_next_slot_cost(player: Player) -> int:
+    """
+    Cost in essence to unlock the next queue slot.
+    Formula: 2^(extra_slots + 1)  →  2, 4, 8, 16 ...
+    """
+    extra = int(getattr(player, "craft_queue_extra_slots", 0) or 0)
+    return 2 ** (extra + 1)
+
+
+def update_craft_jobs_for_player(session: Session, player: Player) -> list:
+    """
+    Update all active and queued craft jobs for this player:
+      - compute how many units should be completed based on time (active jobs)
+      - credit missing items into PlayerItem
+      - mark active job as done when finished
+      - promote the next queued job to active
+
+    Returns a list of item_keys that were just completed (for notifications).
     Notes:
       - This function does NOT commit; caller decides transaction boundaries.
     """
@@ -229,8 +249,10 @@ def update_craft_jobs_for_player(session: Session, player: Player) -> None:
     from app.quests.service import on_item_crafted
 
     now = dt.datetime.utcnow()
+    just_completed: list = []
 
-    jobs = (
+    # Process active jobs first
+    active_jobs = (
         session.query(PlayerCraftJob)
         .filter(PlayerCraftJob.player_id == player.id)
         .filter(PlayerCraftJob.status == "active")
@@ -238,12 +260,13 @@ def update_craft_jobs_for_player(session: Session, player: Player) -> None:
         .all()
     )
 
-    for job in jobs:
+    for job in active_jobs:
         total = int(job.quantity_total or 0)
         done = int(job.quantity_done or 0)
 
         if total <= 0:
             job.status = "done"
+            just_completed.append(job.item_key)
             continue
 
         total_duration = (job.ends_at - job.started_at).total_seconds()
@@ -289,3 +312,34 @@ def update_craft_jobs_for_player(session: Session, player: Player) -> None:
 
         if completed_units >= total or now >= job.ends_at:
             job.status = "done"
+            just_completed.append(job.item_key)
+
+    # After processing active jobs, check if we can promote a queued job
+    still_has_active = (
+        session.query(PlayerCraftJob)
+        .filter(PlayerCraftJob.player_id == player.id)
+        .filter(PlayerCraftJob.status == "active")
+        .count()
+    ) > 0
+
+    if not still_has_active:
+        # Find the oldest queued job and promote it
+        next_queued = (
+            session.query(PlayerCraftJob)
+            .filter(PlayerCraftJob.player_id == player.id)
+            .filter(PlayerCraftJob.status == "queued")
+            .order_by(PlayerCraftJob.id.asc())
+            .first()
+        )
+        if next_queued:
+            # Get craft duration from CRAFT_DEFS
+            cfg = craft_defs.CRAFT_DEFS.get(next_queued.item_key, {}) or {}
+            recipe = cfg.get("recipe") or {}
+            craft_time_seconds = int(recipe.get("craft_time_seconds") or 0)
+            total_duration_secs = craft_time_seconds * int(next_queued.quantity_total or 1)
+
+            next_queued.status = "active"
+            next_queued.started_at = now
+            next_queued.ends_at = now + dt.timedelta(seconds=total_duration_secs)
+
+    return just_completed

--- a/app/static/GAME_UI/css/global/modals/craft_modal.css
+++ b/app/static/GAME_UI/css/global/modals/craft_modal.css
@@ -386,28 +386,216 @@
 }
 
 /* ------------------------------------------------------------
-   7) Actions (quantity + craft button)
+   7) Queue bar (active job + queue slots + unlock button)
    ------------------------------------------------------------ */
-.craft-quantity-row {
+
+.craft-queue-bar {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-top: 4px;
-  margin-bottom: 4px;
-  font-size: 0.8rem;
+  margin-bottom: 10px;
+  padding: 8px 10px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  flex-wrap: wrap;
+  transition: border-color 0.3s ease;
+}
+
+/* Highlight border when a craft is active */
+.craft-queue-bar.has-active-job {
+  border-color: rgba(34, 197, 94, 0.35);
+}
+
+/* Active job display */
+.craft-active-job-display {
+  flex: 1;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.craft-job-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.craft-job-icon-wrap {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.craft-job-icon {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.craft-job-icon-fallback {
+  font-size: 1rem;
+}
+
+.craft-job-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.craft-job-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #e5e7eb;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.craft-job-timer {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.craft-timer-clock {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #22c55e;
+  letter-spacing: 1px;
+  font-variant-numeric: tabular-nums;
+}
+
+.craft-timer-sep {
+  color: #4b5563;
+  font-size: 0.75rem;
+}
+
+.craft-timer-qty {
+  font-size: 0.75rem;
   color: #9ca3af;
 }
 
-.craft-quantity-row input {
-  width: 70px;
-  padding: 4px 6px;
-  border-radius: 6px;
-  border: 1px solid rgba(148, 163, 184, 0.6);
-  background: rgba(15, 23, 42, 0.9);
-  color: #e5e7eb;
-  font-size: 0.8rem;
+/* Progress bar */
+.craft-progress-wrap {
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
 }
 
+.craft-progress-bar {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(to right, #22c55e, #4ade80);
+  transition: width 1s linear;
+}
+
+/* Queue slots (pending jobs) */
+.craft-queue-slots {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.craft-queue-slot-item {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.craft-queue-slot-item img {
+  width: 26px;
+  height: 26px;
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.craft-queue-slot-empty {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  border: 1px dashed rgba(148, 163, 184, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.craft-queue-slot-empty-icon {
+  font-size: 1rem;
+  color: rgba(148, 163, 184, 0.2);
+}
+
+/* Unlock slot button */
+.craft-unlock-slot-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+  padding: 5px 8px;
+  border-radius: 10px;
+  border: 1px dashed rgba(250, 204, 21, 0.5);
+  background: rgba(15, 23, 42, 0.7);
+  color: #fbbf24;
+  cursor: pointer;
+  font-size: 0.7rem;
+  flex-shrink: 0;
+  transition: background 0.12s ease;
+}
+
+.craft-unlock-slot-btn:hover {
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.craft-unlock-slot-icon {
+  font-size: 1.1rem;
+  line-height: 1;
+  font-weight: 700;
+}
+
+.craft-unlock-slot-cost {
+  font-size: 0.68rem;
+  color: #fbbf24;
+}
+
+/* ------------------------------------------------------------
+   7b) Recipe duration hint (below table title)
+   ------------------------------------------------------------ */
+.craft-recipe-duration {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 4px;
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.craft-duration-icon {
+  font-size: 0.85rem;
+}
+
+/* ------------------------------------------------------------
+   7c) Craft perform button
+   ------------------------------------------------------------ */
 .craft-perform-btn {
   margin-top: 4px;
   padding: 8px 10px;
@@ -457,6 +645,8 @@
   justify-content: center;
   cursor: pointer;
   z-index: 50;
+  /* needed so absolute .craft-fab-dot is positioned relative to this button */
+  overflow: visible;
 }
 
 .craft-fab-btn img {
@@ -468,6 +658,63 @@
 .craft-fab-btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 14px 30px rgba(0, 0, 0, 0.65);
+}
+
+/* Red notification dot on FAB */
+.craft-fab-dot {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #ef4444;
+  border: 2px solid #16a34a;
+  animation: craft-dot-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes craft-dot-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.25); opacity: 0.8; }
+}
+
+/* Craft completion toast (game-level, outside modal) */
+.craft-done-toast {
+  position: fixed;
+  bottom: 80px;
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(34, 197, 94, 0.6);
+  color: #bbf7d0;
+  font-size: 0.82rem;
+  font-weight: 500;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  z-index: 9999;
+  white-space: nowrap;
+}
+
+.craft-done-toast.is-visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.craft-done-toast-icon {
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+/* Suppress the old craft-status box (replaced by queue bar) */
+.craft-status {
+  display: none !important;
 }
 
 /* ------------------------------------------------------------

--- a/app/static/GAME_UI/js/craft_app.js
+++ b/app/static/GAME_UI/js/craft_app.js
@@ -14,8 +14,7 @@ let craftState = {
   recipes: [],
   selectedRecipe: null,
 
-  // Craft table level:
-  // 0: no table, 1: 1x3, 2: 2x3, 3: 3x3
+  // Craft table level: 0 / 1 / 2 / 3
   tableLevel: 0,
 
   // Player inventory from /api/state
@@ -33,17 +32,27 @@ let craftState = {
   // Toggle ingredients / recipes panel
   showRecipes: false,
 
-  // Craft job state (single job per table)
-  activeJob: null,        // current craft job
-  jobRemainingSeconds: 0, // local countdown for UI
+  // Craft queue state
+  activeJob: null,     // currently crafting
+  queueJobs: [],       // waiting in queue
+  maxQueueSlots: 2,    // base 2 + extra purchased
+  extraSlots: 0,
+  nextSlotCost: 2,
 
   // Filters (text input)
   ingredientsFilter: "",
   recipesFilter: "",
 };
 
-// Timer id for craft job countdown
-let craftJobTimerId = null;
+// Set of job IDs for which we've already shown a "done" toast
+const _craftShownDoneIds = new Set();
+
+// Interval ID for the progress/timer loop
+let craftTimerLoopId = null;
+
+// Track progress per job so the bar never goes backwards
+let _craftProgressJobId = null;
+let _craftProgressPct   = 0;
 
 // Currently dragged ingredient key (for slot hover highlight)
 let currentDraggedKey = null;
@@ -82,12 +91,10 @@ function showCraftMobileTooltip(text) {
 
 
 // ============================================================================
-// Generic helpers
+// Craft queue bar rendering
 // ============================================================================
 
-/**
- * Format seconds as "mm:ss".
- */
+/** Format seconds as "mm:ss" */
 function formatSecondsMMSS(total) {
   const sec = Math.max(0, parseInt(total, 10) || 0);
   const m = Math.floor(sec / 60);
@@ -95,27 +102,185 @@ function formatSecondsMMSS(total) {
   return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
 }
 
-// ============================================================================
-// Craft status (top UI)
-// ============================================================================
+/** Show/hide the craft FAB red dot */
+function updateCraftFabDot(show) {
+  const dot = document.getElementById("craft-fab-dot");
+  if (!dot) return;
+  dot.style.display = show ? "" : "none";
+}
 
+/** Show a "craft done" toast above the FAB button */
+function showCraftDoneToast(label, qty) {
+  let toast = document.querySelector(".craft-done-toast");
+  if (!toast) {
+    toast = document.createElement("div");
+    toast.className = "craft-done-toast";
+    const icon = document.createElement("span");
+    icon.className = "craft-done-toast-icon";
+    icon.textContent = "✓";
+    toast.appendChild(icon);
+    const text = document.createElement("span");
+    text.className = "craft-done-toast-text";
+    toast.appendChild(text);
+    document.body.appendChild(toast);
+  }
+
+  const text = toast.querySelector(".craft-done-toast-text");
+  if (text) text.textContent = `Craft terminé : ×${qty} ${label}`;
+
+  toast.classList.add("is-visible");
+  setTimeout(() => toast.classList.remove("is-visible"), 3500);
+}
+
+/**
+ * Render the queue bar (active job + queue slots + unlock button).
+ * Called every second by the timer loop AND after each data refresh.
+ */
+function renderCraftQueueBar() {
+  const bar = document.getElementById("craft-queue-bar");
+  if (!bar) return;
+
+  // Show the bar whenever the player has a craft table
+  bar.style.display = craftState.tableLevel > 0 ? "flex" : "none";
+
+  const job = craftState.activeJob;
+  bar.classList.toggle("has-active-job", !!job);
+
+  // --- Active job section ---
+  const jobIcon  = document.getElementById("craft-job-icon");
+  const jobIconFb = document.getElementById("craft-job-icon-fallback");
+  const jobName  = document.getElementById("craft-job-name");
+  const timerClock = document.getElementById("craft-timer-clock");
+  const timerQty = document.getElementById("craft-timer-qty");
+  const progressBar = document.getElementById("craft-progress-bar");
+
+  if (job) {
+    // Icon
+    if (jobIcon) {
+      if (job.icon) {
+        let src = job.icon;
+        if (!src.startsWith("/") && !src.startsWith("http")) src = "/" + src;
+        jobIcon.src = src;
+        jobIcon.style.display = "";
+        if (jobIconFb) jobIconFb.style.display = "none";
+      } else {
+        jobIcon.style.display = "none";
+        if (jobIconFb) jobIconFb.style.display = "";
+      }
+    }
+
+    if (jobName) jobName.textContent = job.label || job.item_key || "—";
+
+    // Compute remaining time from ends_at
+    // Backend returns naive UTC strings (no "Z"), so we append it to force UTC parsing
+    const _addZ = (s) => (s && !s.endsWith("Z") && !s.includes("+") ? s + "Z" : s);
+    const now = Date.now() / 1000;
+    const endsAt = new Date(_addZ(job.ends_at)).getTime() / 1000;
+    const startedAt = new Date(_addZ(job.started_at)).getTime() / 1000;
+    const totalSecs = Math.max(1, endsAt - startedAt);
+    const remaining = Math.max(0, endsAt - now);
+    const elapsed = totalSecs - remaining;
+    const progress = Math.min(100, (elapsed / totalSecs) * 100);
+
+    if (timerClock) timerClock.textContent = formatSecondsMMSS(Math.ceil(remaining));
+    if (timerQty) timerQty.textContent = `×${job.quantity_total || 1}`;
+    if (progressBar) {
+      // Never allow progress to go backwards for the same job
+      if (_craftProgressJobId !== job.id) {
+        _craftProgressJobId = job.id;
+        _craftProgressPct   = 0;
+      }
+      _craftProgressPct = Math.max(_craftProgressPct, progress);
+      progressBar.style.width = _craftProgressPct + "%";
+    }
+  }
+
+  // Show/hide the whole active-job display based on whether a job is running
+  const activeDisplay = document.getElementById("craft-active-job-display");
+  if (activeDisplay) activeDisplay.style.display = job ? "flex" : "none";
+
+  // --- Queue slots (waiting) ---
+  renderCraftQueueSlots();
+
+  // --- Unlock slot button (always visible when table unlocked) ---
+  const unlockBtn  = document.getElementById("craft-unlock-slot-btn");
+  const costSpan   = document.getElementById("craft-unlock-slot-cost");
+  if (unlockBtn) {
+    unlockBtn.style.display = craftState.tableLevel > 0 ? "" : "none";
+    if (costSpan) costSpan.textContent = `${craftState.nextSlotCost} ✦`;
+  }
+}
+
+/** Render queue slot items (waiting jobs + empty slots) */
+function renderCraftQueueSlots() {
+  const container = document.getElementById("craft-queue-slots");
+  if (!container) return;
+  container.innerHTML = "";
+
+  const queuedJobs = craftState.queueJobs || [];
+  // Extra queue capacity beyond active slot = maxQueueSlots - 1
+  const queueCapacity = Math.max(0, craftState.maxQueueSlots - 1);
+
+  for (let i = 0; i < queueCapacity; i++) {
+    const queued = queuedJobs[i] || null;
+    const el = document.createElement("div");
+
+    if (queued) {
+      el.className = "craft-queue-slot-item";
+      el.title = queued.label || queued.item_key;
+      if (queued.icon) {
+        const img = document.createElement("img");
+        let src = queued.icon;
+        if (!src.startsWith("/") && !src.startsWith("http")) src = "/" + src;
+        img.src = src;
+        img.alt = queued.label || queued.item_key;
+        el.appendChild(img);
+      } else {
+        el.textContent = "⚙";
+        el.style.fontSize = "1rem";
+        el.style.color = "#9ca3af";
+      }
+    } else {
+      el.className = "craft-queue-slot-empty";
+      const icon = document.createElement("span");
+      icon.className = "craft-queue-slot-empty-icon";
+      icon.textContent = "·";
+      el.appendChild(icon);
+    }
+    container.appendChild(el);
+  }
+}
+
+/** Start (or restart) the 1-second timer loop that updates the queue bar */
+function startCraftTimerLoop() {
+  if (craftTimerLoopId) {
+    clearInterval(craftTimerLoopId);
+    craftTimerLoopId = null;
+  }
+
+  if (!craftState.activeJob) return;
+
+  let ticksSinceSync = 0;
+
+  craftTimerLoopId = setInterval(() => {
+    renderCraftQueueBar();
+    ticksSinceSync++;
+
+    // Every 5 ticks (~5 seconds), resync with backend
+    if (ticksSinceSync >= 5) {
+      ticksSinceSync = 0;
+      clearInterval(craftTimerLoopId);
+      craftTimerLoopId = null;
+      refreshCraftData().catch((e) =>
+        console.error("[craft] timer resync error:", e)
+      );
+    }
+  }, 1000);
+}
+
+/** Legacy stub (used in a few places) - now a no-op */
 function setCraftStatus(text, tone) {
-  const box = document.getElementById("craft-status");
-  const textEl = document.getElementById("craft-status-text");
-  if (!box || !textEl) return;
-
-  // Reset tones
-  box.classList.remove(
-    "craft-status--neutral",
-    "craft-status--running",
-    "craft-status--error",
-    "craft-status--success"
-  );
-
-  const t = (tone || "neutral").toLowerCase();
-  box.classList.add("craft-status--" + t);
-
-  textEl.textContent = text || "Aucun craft en cours.";
+  // Queue bar replaced the old status box. No-op kept for compatibility.
 }
 
 
@@ -150,153 +315,19 @@ function updateSlotHover(slotIndex, isOver) {
 
 
 // ============================================================================
-// Craft job status + timer
+// Legacy stubs (kept for compatibility with code paths that may call them)
 // ============================================================================
 
-/**
- * Check if the current job is actually still active (units + seconds).
- */
 function isCraftJobActive() {
-  const job = craftState.activeJob;
-  if (!job) return false;
-
-  const remainingUnits =
-    job.remaining_units != null
-      ? job.remaining_units
-      : Math.max(
-          0,
-          (job.quantity_total || 0) - (job.quantity_done || 0)
-        );
-
-  const serverRemaining =
-    typeof job.seconds_remaining_total === "number"
-      ? job.seconds_remaining_total
-      : 0;
-
-  const sec =
-    craftState.jobRemainingSeconds > 0
-      ? craftState.jobRemainingSeconds
-      : serverRemaining;
-
-  return remainingUnits > 0 && sec > 0;
+  return !!(craftState.activeJob);
 }
 
-/**
- * Update the craft job status UI box.
- */
 function renderCraftJobStatus() {
-  const job = craftState.activeJob;
-
-  // No job running
-  if (!job || !isCraftJobActive()) {
-    setCraftStatus("Aucun craft en cours.", "neutral");
-    return;
-  }
-
-  const label = job.label || job.item_key || "Item";
-
-  const remainingUnits =
-    job.remaining_units != null
-      ? job.remaining_units
-      : Math.max(0, (job.quantity_total || 0) - (job.quantity_done || 0));
-
-  const serverRemaining =
-    typeof job.seconds_remaining_total === "number"
-      ? job.seconds_remaining_total
-      : 0;
-
-  const sec =
-    craftState.jobRemainingSeconds > 0
-      ? craftState.jobRemainingSeconds
-      : serverRemaining;
-
-  setCraftStatus(
-    `Craft en cours : ${remainingUnits} × ${label} — temps restant : ${formatSecondsMMSS(sec)}`,
-    "running"
-  );
+  renderCraftQueueBar();
 }
 
-
-/**
- * Setup / reset local countdown from activeJob (including periodic resync).
- */
 function setupCraftJobTimerFromState() {
-  // Clear previous timer
-  if (craftJobTimerId) {
-    clearInterval(craftJobTimerId);
-    craftJobTimerId = null;
-  }
-
-  const job = craftState.activeJob;
-
-  // If no job or already finished → clean state
-  if (!job || !isCraftJobActive()) {
-    craftState.activeJob = null;
-    craftState.jobRemainingSeconds = 0;
-    renderCraftJobStatus();
-    return;
-  }
-
-  const serverRemaining =
-    typeof job.seconds_remaining_total === "number"
-      ? job.seconds_remaining_total
-      : 0;
-
-  craftState.jobRemainingSeconds = Math.max(
-    0,
-    parseInt(serverRemaining, 10) || 0
-  );
-
-  // First render immediately
-  renderCraftJobStatus();
-
-  if (craftState.jobRemainingSeconds <= 0) {
-    craftState.activeJob = null;
-    renderCraftJobStatus();
-    return;
-  }
-
-  // Keep track of last remaining seconds when we synced
-  let lastSyncRemaining = craftState.jobRemainingSeconds;
-
-  craftJobTimerId = setInterval(() => {
-    if (craftState.jobRemainingSeconds > 0) {
-      craftState.jobRemainingSeconds -= 1;
-      renderCraftJobStatus();
-
-      // Every 5 seconds, re-sync with backend (/api/state)
-      if (
-        craftState.jobRemainingSeconds > 0 &&
-        lastSyncRemaining - craftState.jobRemainingSeconds >= 5
-      ) {
-        lastSyncRemaining = craftState.jobRemainingSeconds;
-
-        // This will refresh job, inventory, etc.
-        refreshCraftData()
-          .catch((e) => console.error("[craft] refreshCraftData (poll) error:", e));
-
-        // refreshCraftData will call setupCraftJobTimerFromState again
-        // so we stop the current timer.
-        clearInterval(craftJobTimerId);
-        craftJobTimerId = null;
-        return;
-      }
-
-      // End of local timer
-      if (craftState.jobRemainingSeconds <= 0) {
-        clearInterval(craftJobTimerId);
-        craftJobTimerId = null;
-
-        // Final resync to close job and update inventory/items
-        refreshCraftData().catch((e) => {
-          console.error("[craft] refreshCraftData after timer error:", e);
-        });
-      }
-    } else {
-      clearInterval(craftJobTimerId);
-      craftJobTimerId = null;
-    }
-  }, 1000);
+  startCraftTimerLoop();
 }
 
 
@@ -325,8 +356,19 @@ function rebuildCraftGrid() {
 
   const slotsCount = getCraftGridSlotCount();
 
+  // Only wipe slot state + rebuild DOM when the grid size actually changes.
+  // This prevents ghost icons disappearing on every 5-second resync.
+  const domSlots = grid.querySelectorAll(".craft-slot").length;
+  if (domSlots === slotsCount) {
+    // Grid size unchanged — just re-render the existing slots
+    renderCraftSlots();
+    return;
+  }
+
+  // Grid size changed (or first build): reset and rebuild fully
   craftState.expectedSlots = new Array(slotsCount).fill(null);
   craftState.filledSlots   = new Array(slotsCount).fill(null);
+  craftState.selectedRecipe = null;
 
   grid.innerHTML = "";
 
@@ -347,13 +389,6 @@ function rebuildCraftGrid() {
         return;
       }
 
-      // If a craft job is active, do not allow drop
-      if (craftState.activeJob) {
-        slotEl.classList.remove("craft-slot--droppable");
-        return;
-      }
-
-      // Highlight only if dragged ingredient matches expected key
       if (currentDraggedKey && currentDraggedKey === expected.key) {
         slotEl.classList.add("craft-slot--droppable");
       } else {
@@ -433,6 +468,12 @@ function initCraftUI() {
   // Perform craft / change panel
   performBtn.addEventListener("click", onCraftPerformClicked);
 
+  // Buy extra queue slot
+  const unlockSlotBtn = $("craft-unlock-slot-btn");
+  if (unlockSlotBtn) {
+    unlockSlotBtn.addEventListener("click", onBuyQueueSlotClicked);
+  }
+
   // Filters
   if (ingredientsFilterInput) {
     ingredientsFilterInput.addEventListener("input", (e) => {
@@ -483,6 +524,9 @@ function openCraftModal() {
 
   modalEl.classList.add("is-open");
 
+  // Clear notification dot when opening
+  updateCraftFabDot(false);
+
   // Reload state when opening
   refreshCraftData().catch((e) => {
     console.error("[craft] refreshCraftData (open) error:", e);
@@ -523,8 +567,6 @@ async function refreshCraftData() {
       ? craftBlock.craft_table_level
       : 0;
 
-  console.log("[craft] tableLevel from /api/state =", craftState.tableLevel);
-
   // Resource definitions (icons, labels, etc.)
   craftState.resourceDefs =
     state.resources || state.resource_defs || state.resourceDefinitions || [];
@@ -544,9 +586,7 @@ async function refreshCraftData() {
     };
   });
 
-  // Build merged inventory for craft table:
-  //  - resources from state.inventory
-  //  - items from state.items
+  // Build merged inventory
   const resInv = (state.inventory || []).map((rs) => ({
     key: rs.resource || rs.key,
     qty:
@@ -566,16 +606,34 @@ async function refreshCraftData() {
 
   craftState.inventory = [...resInv, ...itemsInv];
 
-  // Active job from backend state
-  craftState.activeJob = craftBlock.active_job || null;
-  console.log("[craft] activeJob from /api/state =", craftState.activeJob);
+  // Queue state from backend
+  craftState.activeJob   = craftBlock.active_job  || null;
+  craftState.queueJobs   = craftBlock.queue_jobs  || [];
+  craftState.maxQueueSlots = craftBlock.max_queue_slots || 2;
+  craftState.extraSlots    = craftBlock.extra_slots || 0;
+  craftState.nextSlotCost  = craftBlock.next_slot_cost || 2;
 
-  const levelSpan = $("craft-table-level");
-  if (levelSpan) {
-    levelSpan.textContent = craftState.tableLevel;
+  // Recently-completed jobs → show toasts + red dot
+  const recentDone = craftBlock.recently_completed || [];
+  let hasNew = false;
+  recentDone.forEach((rc) => {
+    if (!_craftShownDoneIds.has(rc.id)) {
+      _craftShownDoneIds.add(rc.id);
+      showCraftDoneToast(rc.label || rc.item_key, rc.quantity_total || 1);
+      hasNew = true;
+    }
+  });
+  if (hasNew) {
+    // Only show dot if modal is not currently open
+    const modalEl = $("craft-modal");
+    if (!modalEl || !modalEl.classList.contains("is-open")) {
+      updateCraftFabDot(true);
+    }
   }
 
-  // Rebuild grid according to table level
+  const levelSpan = $("craft-table-level");
+  if (levelSpan) levelSpan.textContent = craftState.tableLevel;
+
   rebuildCraftGrid();
 
   // FAB craft button visible only if tableLevel > 0
@@ -584,11 +642,11 @@ async function refreshCraftData() {
     craftBtn.style.display = craftState.tableLevel > 0 ? "" : "none";
   }
 
-  // Render ingredients (with filter)
   renderCraftIngredients(craftState.inventory);
 
-  // Update job status + timer
-  setupCraftJobTimerFromState();
+  // Render queue bar + start timer loop
+  renderCraftQueueBar();
+  startCraftTimerLoop();
 
   // 2) Load recipes
   const recipesRes = await http(
@@ -722,16 +780,6 @@ function renderCraftIngredients(inventory) {
       item.draggable = true;
 
       item.addEventListener("dragstart", (e) => {
-        if (craftState.activeJob) {
-          e.preventDefault();
-          const errEl = $("craft-error");
-          if (errEl) {
-            errEl.style.display = "block";
-            errEl.textContent =
-              "Un craft est déjà en cours. Attends la fin avant de lancer un autre craft.";
-          }
-          return;
-        }
         currentDraggedKey = key;
         e.dataTransfer.setData("text/plain", key);
       });
@@ -761,8 +809,6 @@ function renderCraftIngredients(inventory) {
 // ============================================================================
 
 function onIngredientClickedMobile(key) {
-  if (craftState.activeJob) return;
-
   const expected = craftState.expectedSlots || [];
   const filled = craftState.filledSlots || [];
 
@@ -927,16 +973,6 @@ function renderCraftRecipes(recipes) {
 
     // Click: sélection de la recette
     item.addEventListener("click", () => {
-      if (craftState.activeJob) {
-        const errEl = $("craft-error");
-        if (errEl) {
-          errEl.style.display = "block";
-          errEl.textContent =
-            "Un craft est en cours sur cette table. Termine-le avant de choisir une nouvelle recette.";
-        }
-        return;
-      }
-
       craftState.selectedRecipe = r;
       decodeRecipeIntoSlots(r);
       renderCraftSlots();
@@ -1136,17 +1172,6 @@ function renderCraftSlots() {
 function onSlotDropped(e, slotIndex) {
   e.preventDefault();
 
-  // Do not allow drop if a craft job is running
-  if (craftState.activeJob) {
-    const errEl = $("craft-error");
-    if (errEl) {
-      errEl.style.display = "block";
-      errEl.textContent =
-        "Un craft est déjà en cours. Attends la fin avant de lancer un autre craft.";
-    }
-    return;
-  }
-
   const key = e.dataTransfer.getData("text/plain") || currentDraggedKey;
   if (!key) return;
 
@@ -1218,7 +1243,7 @@ function updateCraftPanelsVisibility() {
 function updateCraftSelectionUI() {
   const performBtn = $("craft-perform-btn");
 
-  renderCraftJobStatus();
+  renderCraftQueueBar();
 
   // Highlight selected recipe in list
   const listEl = $("craft-recipes-list");
@@ -1226,10 +1251,7 @@ function updateCraftSelectionUI() {
     const items = listEl.querySelectorAll(".craft-recipe-item");
     items.forEach((el) => {
       const key = el.getAttribute("data-itemKey");
-      if (
-        craftState.selectedRecipe &&
-        key === craftState.selectedRecipe.item_key
-      ) {
+      if (craftState.selectedRecipe && key === craftState.selectedRecipe.item_key) {
         el.classList.add("is-selected");
       } else {
         el.classList.remove("is-selected");
@@ -1237,62 +1259,56 @@ function updateCraftSelectionUI() {
     });
   }
 
+  // Show duration hint for selected recipe
+  const durationEl = $("craft-recipe-duration");
+  const durationText = $("craft-duration-text");
+  if (durationEl && durationText) {
+    const recipe = craftState.selectedRecipe;
+    const tps = recipe?.recipe?.craft_time_seconds || 0;
+    if (recipe && tps > 0) {
+      durationText.textContent = formatSecondsMMSS(tps) + " par item";
+      durationEl.style.display = "flex";
+    } else if (recipe && tps === 0) {
+      durationText.textContent = "Instantané";
+      durationEl.style.display = "flex";
+    } else {
+      durationEl.style.display = "none";
+    }
+  }
+
   if (!performBtn) return;
 
-  // Button text depends on current panel
+  // Button text
+  performBtn.textContent = craftState.showRecipes ? "Choisir cette recette" : "Craft";
+
+  // --- CASE 1: Recipes panel ---
   if (craftState.showRecipes) {
-    performBtn.textContent = "Crafter cette recette";
-  } else {
-    performBtn.textContent = "Craft";
+    performBtn.disabled = !craftState.selectedRecipe;
+    return;
   }
 
-  // If a craft job is active, always disable button
-  if (craftState.activeJob) {
+  // --- CASE 2: Ingredients panel ---
+  if (!craftState.selectedRecipe || !craftState.tableLevel || craftState.tableLevel <= 0) {
     performBtn.disabled = true;
     return;
   }
 
-  // --- CASE 1: Recipes panel ----------------------------------------------
-  // Here the button is only a "continue" to ingredients, not a real POST yet.
-  if (craftState.showRecipes) {
-    if (!craftState.selectedRecipe) {
-      performBtn.disabled = true;
-    } else {
-      performBtn.disabled = false;
-    }
-    return;
-  }
-
-  // --- CASE 2: Ingredients panel (normal craft flow) ----------------------
-
-  // No recipe selected
-  if (!craftState.selectedRecipe) {
-    performBtn.disabled = true;
-    return;
-  }
-
-  // No table => cannot craft
-  if (!craftState.tableLevel || craftState.tableLevel <= 0) {
-    performBtn.disabled = true;
-    return;
-  }
-
-  // Recipe locked (level, card, table, etc.)
   if (!craftState.selectedRecipe.is_unlocked) {
     performBtn.disabled = true;
     return;
   }
 
-  // All expected slots must be filled with the correct key
-  console.log(
-    "[craft] updateUI selected=",
-    !!craftState.selectedRecipe,
-    "expected=",
-    craftState.expectedSlots,
-    "filled=",
-    craftState.filledSlots
-  );
+  // Queue full check (only for delayed crafts)
+  const tps = craftState.selectedRecipe?.recipe?.craft_time_seconds || 0;
+  if (tps > 0) {
+    const occupied = (craftState.activeJob ? 1 : 0) + craftState.queueJobs.length;
+    if (occupied >= craftState.maxQueueSlots) {
+      performBtn.disabled = true;
+      return;
+    }
+  }
 
+  // All expected slots must be filled
   const allGood = craftState.expectedSlots.every((exp, i) => {
     if (!exp) return true;
     const filled = craftState.filledSlots[i];
@@ -1309,133 +1325,120 @@ function updateCraftSelectionUI() {
 
 async function onCraftPerformClicked() {
   const performBtn = $("craft-perform-btn");
-  const qtyInput   = $("craft-quantity-input");
 
-  // If a job is active → nothing to do
-  if (craftState.activeJob) {
-    setCraftStatus(
-      "Un craft est déjà en cours. Attends sa fin avant de lancer un autre craft.",
-      "error"
-    );
-    return;
-  }
-
-  // --- CASE 1: Recipes panel ----------------------------------------------
-  // Here, "Crafter cette recette" only switches to ingredients panel.
+  // --- CASE 1: Recipes panel → switch to ingredients panel ---
   if (craftState.showRecipes) {
-    if (!craftState.selectedRecipe) {
-      // No recipe selected → nothing
-      return;
-    }
-
+    if (!craftState.selectedRecipe) return;
     craftState.showRecipes = false;
     updateCraftPanelsVisibility();
     updateCraftSelectionUI();
     return;
   }
 
-  // --- CASE 2: Ingredients panel (launch craft) ---------------------------
+  // --- CASE 2: Ingredients panel → launch craft ---
   if (!craftState.selectedRecipe) return;
 
-  // Quantity
-  let times = 1;
-  if (qtyInput) {
-    const v = parseInt(qtyInput.value, 10);
-    times = Number.isNaN(v) || v < 1 ? 1 : v;
-    qtyInput.value = String(times);
-  }
-
-  if (performBtn) {
-    performBtn.disabled = true;
-  }
+  if (performBtn) performBtn.disabled = true;
 
   const itemKey = craftState.selectedRecipe.item_key;
-
-  const payload = {
-    item_key: itemKey,
-    craft_location: "craft_table",
-    times: times,
-  };
-
-  console.log("[craft] perform =>", {
-    ...payload,
-    filledSlots: craftState.filledSlots,
-    expectedSlots: craftState.expectedSlots,
-  });
+  const payload = { item_key: itemKey, craft_location: "craft_table", times: 1 };
 
   const res = await http("POST", "/api/craft/perform", payload);
 
   if (!res.ok) {
-    console.error("[craft] perform error:", res);
-    console.error("[craft] perform error data:", res.data);
-    console.error("[craft] perform error data (pretty):", JSON.stringify(res.data, null, 2));
-
-
-    if (performBtn) {
-      performBtn.disabled = false;
-    }
+    if (performBtn) performBtn.disabled = false;
 
     const data = res.data || {};
     const code = data.error || "";
 
-    if (code === "not_enough_resources") {
+    let errMsg = "Erreur lors du craft.";
+    if (code === "craft_queue_full") {
+      errMsg = `File de craft pleine (${data.occupied}/${data.max_slots}). Débloque un emplacement supplémentaire.`;
+    } else if (code === "not_enough_ingredients") {
       const missing = data.missing || {};
-      const parts = Object.entries(missing).map(([k, v]) => `${v} x ${k}`);
-      setCraftStatus(
-        "Pas assez de ressources: " + (parts.join(", ") || "inconnu"),
-        "error"
-      );
+      const all = { ...(missing.resources || {}), ...(missing.items || {}) };
+      const parts = Object.entries(all).map(([k, v]) => `${v} × ${k}`);
+      errMsg = "Ingrédients manquants : " + (parts.join(", ") || "?");
     } else if (code === "craft_locked") {
-      setCraftStatus("Recette verrouillée.", "error");
+      errMsg = "Recette verrouillée.";
     } else if (code === "craft_table_too_low") {
-      setCraftStatus("Table de craft de niveau insuffisant.", "error");
-    } else if (code === "craft_in_progress") {
-      setCraftStatus("Un craft est déjà en cours sur cette table.", "error");
-    } else {
-      setCraftStatus("Erreur lors du craft.", "error");
+      errMsg = "Table de craft de niveau insuffisant.";
     }
 
+    // Show inline error briefly in status area if it exists, otherwise alert
+    const errEl = $("craft-error");
+    if (errEl) {
+      errEl.style.display = "block";
+      errEl.textContent = errMsg;
+      setTimeout(() => { errEl.style.display = "none"; }, 4000);
+    } else {
+      console.warn("[craft] error:", errMsg);
+    }
     return;
   }
 
   const data = res.data || {};
-  const crafted = data.crafted_item || {};
-  const delayed = !!data.delayed;
-
-  // If backend returns rewards (xp/level), trigger global level-up UI if available
   const rewards = data.rewards || null;
-
   if (rewards && rewards.level_up && typeof window.handleLevelUpFront === "function") {
-    window.handleLevelUpFront(
-      rewards.old_level,
-      rewards.new_level,
-      rewards.level_rewards || []
-    );
+    window.handleLevelUpFront(rewards.old_level, rewards.new_level, rewards.level_rewards || []);
   }
 
-  // Reset quantity input to 1 after craft
-  if (qtyInput) {
-    qtyInput.value = "1";
-  }
-
-  // Success message in top status
-  const qty = crafted.quantity || times;
-  const label = crafted.label || crafted.item_key || itemKey;
-
-  if (delayed) {
-    setCraftStatus(`Craft lancé : x${qty} ${label} (en cours...)`, "success");
-  } else {
-    setCraftStatus(`Craft réussi : x${qty} ${label}`, "success");
-  }
-
-  // Refresh ingredients, jobs & timer
+  // Refresh data (updates queue bar, inventory, etc.)
   await refreshCraftData();
 
-  // After refresh, show the job timer if a job is now active
-  renderCraftJobStatus();
-
-  // Reset filled slots but keep pattern
+  // Reset filled slots but keep pattern visible
   craftState.filledSlots = new Array(craftState.expectedSlots.length).fill(null);
   renderCraftSlots();
 }
+
+async function onBuyQueueSlotClicked() {
+  const res = await http("POST", "/api/craft/queue/buy_slot", {});
+  if (!res.ok) {
+    const data = res.data || {};
+    if (data.error === "not_enough_essence") {
+      alert(`Essence insuffisante — il te faut ${data.required} ✦ (tu en as ${data.owned}).`);
+    } else {
+      console.error("[craft] buy_slot error:", data);
+    }
+    return;
+  }
+  await refreshCraftData();
+}
+
+
+// ============================================================================
+// Background craft-done polling (runs even when modal is closed)
+// ============================================================================
+
+(function startCraftBackgroundPoll() {
+  // Poll every 30 seconds when modal is closed (timer loop handles it when open)
+  setInterval(async () => {
+    const modalEl = document.getElementById("craft-modal");
+    if (modalEl && modalEl.classList.contains("is-open")) return; // timer loop handles it
+    if (!craftState.activeJob && craftState.queueJobs.length === 0) return; // nothing running
+
+    try {
+      const res = await http("GET", "/api/state");
+      if (!res.ok) return;
+      const craftBlock = (res.data || {}).craft || {};
+
+      // Update queue state silently
+      craftState.activeJob   = craftBlock.active_job  || null;
+      craftState.queueJobs   = craftBlock.queue_jobs  || [];
+      craftState.maxQueueSlots = craftBlock.max_queue_slots || 2;
+      craftState.nextSlotCost  = craftBlock.next_slot_cost || 2;
+
+      const recentDone = craftBlock.recently_completed || [];
+      recentDone.forEach((rc) => {
+        if (!_craftShownDoneIds.has(rc.id)) {
+          _craftShownDoneIds.add(rc.id);
+          showCraftDoneToast(rc.label || rc.item_key, rc.quantity_total || 1);
+          updateCraftFabDot(true);
+        }
+      });
+    } catch (e) {
+      // silent
+    }
+  }, 30000);
+})();
 

--- a/app/static/GAME_UI/js/village/village_shop.js
+++ b/app/static/GAME_UI/js/village/village_shop.js
@@ -56,7 +56,14 @@ async function handleBuy(btn) {
     if (!r.ok) {
       btn.disabled = false;
       btn.textContent = oldLabel;
-      alert((i18n.buy_error || "Error") + " : " + ((r.data || {}).error || "?"));
+      const errData = r.data || {};
+      if (errData.error === "prerequisite_card_required") {
+        const reqKey = errData.requires_card || "";
+        const reqLabel = reqKey.replace(/_/g, " ");
+        alert(`Tu dois d'abord posséder la carte "${reqLabel}" pour acheter celle-ci.`);
+      } else {
+        alert((i18n.buy_error || "Error") + " : " + (errData.error || "?"));
+      }
       return;
     }
 

--- a/app/templates/game_base.html
+++ b/app/templates/game_base.html
@@ -423,12 +423,41 @@
             </button>
           </div>
         </div>
-        <!-- Craft status (always visible) -->
-        <div id="craft-status" class="craft-status">
-          <div id="craft-status-text" class="craft-status-text">
-            {{ t("base.craft.no_job") }}
+        <!-- Queue status bar (always visible when job running) -->
+        <div id="craft-queue-bar" class="craft-queue-bar" style="display:none;">
+          <!-- Active job progress -->
+          <div id="craft-active-job-display" class="craft-active-job-display">
+            <div class="craft-job-header">
+              <div class="craft-job-icon-wrap">
+                <img id="craft-job-icon" src="" alt="" class="craft-job-icon" style="display:none;" />
+                <span id="craft-job-icon-fallback" class="craft-job-icon-fallback">⚙</span>
+              </div>
+              <div class="craft-job-info">
+                <div class="craft-job-name" id="craft-job-name">—</div>
+                <div class="craft-job-timer" id="craft-job-timer">
+                  <span class="craft-timer-clock" id="craft-timer-clock">--:--</span>
+                  <span class="craft-timer-sep">·</span>
+                  <span class="craft-timer-qty" id="craft-timer-qty">×1</span>
+                </div>
+              </div>
+            </div>
+            <div class="craft-progress-wrap">
+              <div class="craft-progress-bar" id="craft-progress-bar" style="width:0%"></div>
+            </div>
           </div>
+
+          <!-- Queue slots (waiting jobs) -->
+          <div id="craft-queue-slots" class="craft-queue-slots">
+            <!-- JS-rendered -->
+          </div>
+
+          <!-- Unlock slot button -->
+          <button id="craft-unlock-slot-btn" class="craft-unlock-slot-btn" title="Débloquer un emplacement">
+            <span class="craft-unlock-slot-icon">+</span>
+            <span id="craft-unlock-slot-cost" class="craft-unlock-slot-cost">2 ✦</span>
+          </button>
         </div>
+
         <div class="craft-modal-body">
           <!-- Left: ingredients + (recipes via toggle) -->
           <div class="craft-left-panel">
@@ -488,11 +517,17 @@
             </div>
           </div>
 
-          <!-- Center: craft grid -->
+          <!-- Right: craft grid + action -->
           <div class="craft-grid-panel">
             <h3 class="craft-section-title">
-              {{ t("base.craft.table") }} ({{ t("base.craft.level") }} <span id="craft-table-level">1</span>)
+              Table (niv.&nbsp;<span id="craft-table-level">1</span>)
             </h3>
+
+            <!-- Selected recipe duration hint -->
+            <div id="craft-recipe-duration" class="craft-recipe-duration" style="display:none;">
+              <span class="craft-duration-icon">⏱</span>
+              <span id="craft-duration-text">—</span>
+            </div>
 
             <div class="craft-grid">
               <div class="craft-slot" data-slot="0"></div>
@@ -500,23 +535,12 @@
               <div class="craft-slot" data-slot="2"></div>
             </div>
 
-            <div class="craft-quantity-row">
-              <label for="craft-quantity-input">{{ t("base.craft.quantity") }}</label>
-              <input
-                id="craft-quantity-input"
-                type="number"
-                min="1"
-                value="1"
-                step="1"
-              />
-            </div>
-
             <button
               id="craft-perform-btn"
               class="craft-perform-btn"
               disabled
             >
-              {{ t("base.craft.perform") }}
+              Craft
             </button>
           </div>
         </div>
@@ -525,7 +549,6 @@
 
     <!-- HUD bottom-left actions -->
     <div class="hud-bottom-left">
-      <!-- autres boutons éventuels... -->
       <button
         id="craft-open-btn"
         class="craft-fab-btn"
@@ -535,6 +558,7 @@
           src="{{ url_for('static', filename='assets/img/ui/craft.png') }}"
           alt="{{ t('base.craft.alt') }}"
         />
+        <span id="craft-fab-dot" class="craft-fab-dot" style="display:none;"></span>
       </button>
     </div>
 


### PR DESCRIPTION
Pour le moment on peut acheter la carte "Access Craft Table Medium" ou "Access Craft Table Advanced" directement. Il faudrait que pour acheter la carte "Access Craft Table Medium" on possède la carte "Access Craft Table Basic". Et que pour acheter la carte "Access Craft Table Advanced" on possède la carte "Access Craft Table Medium".

Pour le moment on peut choisir quelle quantité crafter. Il faudrait plutot un système de queue ou de base on a 2 emplacements (crafte en cours + 1 en file d'attente). On peut débloquer un emplacements en payant 2 essence pour le premier, 4 pour le suivant, 8 ... (x2 à chaque emplacements supplémentaire).

La durée des crafte doit être indiquée sur la page de craft.

Quand un craft est fini, un toast doit apparaitre et une icone (genre boule rouge) doit être présente sur le bouton craft en bas a gauche.

L'affichage du temps restant pour le craft en cours doit être améliorer également (plus design et plus ergonomique)

-----------------------------------

C'est beaucoup mieux mais la barre n'est pas fluide.  Elle par en arrière de temps en temps quand c'est le 2ème craft par exemple.

On ne peut pas acheter de slot supplémentaire si il n'y a pas un craft en cours.

Et quand il y a un craft en cours, les icones translucides dans la grille de craft qui sont là pour nous aider a visualiser ce qu'on doit mettre on tendance a disparaitre si il y a un craft en cours.